### PR TITLE
fix: can't mass assign protected attributes

### DIFF
--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -23,10 +23,8 @@ module Flip
     end
 
     def switch! key, enable
-      @klass.find_or_initialize_by_key(key).tap do |o|
-        o.enabled = enable
-        o.save!
-      end
+      @klass.attr_accessible :enabled
+      @klass.find_or_initialize_by_key(key).update_attributes! enabled: enable
     end
 
     def delete! key

--- a/spec/database_strategy_spec.rb
+++ b/spec/database_strategy_spec.rb
@@ -44,11 +44,13 @@ describe Flip::DatabaseStrategy do
 
   describe "#switch!" do
     it "can switch a feature on" do
+      model_klass.should_receive(:attr_accessible).with(:enabled).and_return(true)
       model_klass.should_receive(:find_or_initialize_by_key).with(:one).and_return(disabled_record)
       disabled_record.should_receive(:update_attributes!).with(enabled: true)
       strategy.switch! :one, true
     end
     it "can switch a feature off" do
+      model_klass.should_receive(:attr_accessible).with(:enabled).and_return(true)
       model_klass.should_receive(:find_or_initialize_by_key).with(:one).and_return(enabled_record)
       enabled_record.should_receive(:update_attributes!).with(enabled: false)
       strategy.switch! :one, false


### PR DESCRIPTION
This pull request fixes a bug whereby toggling a feature in the database results in a "can't mass assign protected attributes" error.
