### PR TITLE
Use string values in AR finders

### DIFF
--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -23,17 +23,17 @@ module Flip
     end
 
     def switch! key, enable
-      @klass.find_or_initialize_by_key(key).update_attributes! enabled: enable
+      @klass.find_or_initialize_by_key(key.to_s).update_attributes! enabled: enable
     end
 
     def delete! key
-      @klass.find_by_key(key).try(:destroy)
+      @klass.find_by_key(key.to_s).try(:destroy)
     end
 
     private
 
     def feature(definition)
-      @klass.find_by_key definition.key
+      @klass.find_by_key definition.key.to_s
     end
 
   end

--- a/spec/database_strategy_spec.rb
+++ b/spec/database_strategy_spec.rb
@@ -44,12 +44,12 @@ describe Flip::DatabaseStrategy do
 
   describe "#switch!" do
     it "can switch a feature on" do
-      model_klass.should_receive(:find_or_initialize_by_key).with(:one).and_return(disabled_record)
+      model_klass.should_receive(:find_or_initialize_by_key).with('one').and_return(disabled_record)
       disabled_record.should_receive(:update_attributes!).with(enabled: true)
       strategy.switch! :one, true
     end
     it "can switch a feature off" do
-      model_klass.should_receive(:find_or_initialize_by_key).with(:one).and_return(enabled_record)
+      model_klass.should_receive(:find_or_initialize_by_key).with('one').and_return(enabled_record)
       enabled_record.should_receive(:update_attributes!).with(enabled: false)
       strategy.switch! :one, false
     end
@@ -57,7 +57,7 @@ describe Flip::DatabaseStrategy do
 
   describe "#delete!" do
     it "can delete a feature record" do
-      model_klass.should_receive(:find_by_key).with(:one).and_return(enabled_record)
+      model_klass.should_receive(:find_by_key).with('one').and_return(enabled_record)
       enabled_record.should_receive(:try).with(:destroy)
       strategy.delete! :one
     end


### PR DESCRIPTION
This is required to use flip in a project that also uses the squeel gem.
When you pass a symbol to a finder method in squeel, squeel assumes you mean
to reference a column rather than converting the symbol to a string to
be used as the value.

As explained in squeel issue ernie/squeel#67
