### PR TITLE
use modern active record calls

### DIFF
--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -25,7 +25,7 @@ module Flip
     def switch! key, enable
       record = @klass.where(key: key.to_s).first_or_initialize
       record.enabled = enable
-      record.save
+      record.save!
     end
 
     def delete! key


### PR DESCRIPTION
Hi.  

 By using more modern AREL-style finders, I found Flip to be more compatible with other gems like squeel.
