### PR TITLE
require correct file in migration generator

### DIFF
--- a/lib/generators/flip/migration/migration_generator.rb
+++ b/lib/generators/flip/migration/migration_generator.rb
@@ -1,4 +1,4 @@
-require "rails/generators/active_record/migration"
+require "rails/generators/migration"
 
 class Flip::MigrationGenerator < Rails::Generators::Base
   include Rails::Generators::Migration


### PR DESCRIPTION
While executing `rails g flip:install` : 

```
lib/ruby/gems/2.0.0/gems/activesupport-4.0.0/lib/active_support/dependencies.rb:228:in `require': cannot load such file -- rails/generators/active_record/migration (LoadError)`
```

This PR fixes this by requiring correct file in migration generator. I tested it on rails 4.0.0 and 3.2.15
