### PR TITLE
Specify feature model name

### DIFF
--- a/lib/flip/declarable.rb
+++ b/lib/flip/declarable.rb
@@ -11,8 +11,8 @@ module Flip
     end
 
     # Adds a strategy for determining feature status.
-    def strategy(strategy)
-      FeatureSet.instance.add_strategy strategy
+    def strategy(strategy, model_klass = nil)
+      FeatureSet.instance.add_strategy strategy, model_klass
     end
 
     # The default response, boolean or a Proc to be called.

--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -32,8 +32,14 @@ module Flip
     end
 
     # Adds a strategy for determing feature status.
-    def add_strategy(strategy)
-      strategy = strategy.new if strategy.is_a? Class
+    def add_strategy(strategy, model_klass = nil)
+      if strategy.is_a? Class
+        if model_klass && model_klass.is_a?(Class)
+          strategy = strategy.new model_klass
+        else
+          strategy = strategy.new
+        end
+      end
       @strategies[strategy.name] = strategy
     end
 


### PR DESCRIPTION
User can specify another model name to use. Like: 

```
class Function < ActiveRecord::Base
  extend Flip::Declarable
  strategy Flip::DatabaseStrategy, Function
end
```

This is another solution for issue #6 
