### PR TITLE
Adds some thread safety to the cookies strategy

### DIFF
--- a/lib/flip/cookie_strategy.rb
+++ b/lib/flip/cookie_strategy.rb
@@ -32,7 +32,7 @@ module Flip
     end
 
     def self.cookies= cookies
-      @cookies = cookies
+      Thread.current[:flip_cookies] = cookies
     end
 
     def cookie_name(definition)
@@ -43,7 +43,7 @@ module Flip
     private
 
     def cookies
-      self.class.instance_variable_get(:@cookies) || {}
+      Thread.current[:flip_cookies] || {}
     end
 
     # Include in ApplicationController to push cookies into CookieStrategy.


### PR DESCRIPTION
The cookie accessor in the cookies strategy was not thread safe and would be clobbered in a concurrent request environment.

A simple change to peg the cookies to the local thread.
