### PR TITLE
Fix rspec deprecations

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency("i18n")
 
   s.add_development_dependency("rspec", "~> 2.5")
+  s.add_development_dependency("rspec-its")
   s.add_development_dependency("rake")
 end

--- a/lib/flip/version.rb
+++ b/lib/flip/version.rb
@@ -1,3 +1,3 @@
 module Flip
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/cookie_strategy_spec.rb
+++ b/spec/cookie_strategy_spec.rb
@@ -26,26 +26,26 @@ describe Flip::CookieStrategy do
   describe "cookie interrogration" do
     context "enabled feature" do
       specify "#knows? is true" do
-        strategy.knows?(:one).should be_true
+        strategy.knows?(:one).should be true
       end
       specify "#on? is true" do
-        strategy.on?(:one).should be_true
+        strategy.on?(:one).should be true
       end
     end
     context "disabled feature" do
       specify "#knows? is true" do
-        strategy.knows?(:two).should be_true
+        strategy.knows?(:two).should be true
       end
       specify "#on? is false" do
-        strategy.on?(:two).should be_false
+        strategy.on?(:two).should be false
       end
     end
     context "feature with no cookie present" do
       specify "#knows? is false" do
-        strategy.knows?(:three).should be_false
+        strategy.knows?(:three).should be false
       end
       specify "#on? is false" do
-        strategy.on?(:three).should be_false
+        strategy.on?(:three).should be false
       end
     end
   end
@@ -53,20 +53,20 @@ describe Flip::CookieStrategy do
   describe "cookie manipulation" do
     it "can switch known features on" do
       strategy.switch! :one, true
-      strategy.on?(:one).should be_true
+      strategy.on?(:one).should be true
     end
     it "can switch unknown features on" do
       strategy.switch! :three, true
-      strategy.on?(:three).should be_true
+      strategy.on?(:three).should be true
     end
     it "can switch features off" do
       strategy.switch! :two, false
-      strategy.on?(:two).should be_false
+      strategy.on?(:two).should be false
     end
     it "can delete knowledge of a feature" do
       strategy.delete! :one
-      strategy.on?(:one).should be_false
-      strategy.knows?(:one).should be_false
+      strategy.on?(:one).should be false
+      strategy.knows?(:one).should be false
     end
   end
 

--- a/spec/database_strategy_spec.rb
+++ b/spec/database_strategy_spec.rb
@@ -17,7 +17,7 @@ describe Flip::DatabaseStrategy do
 
   subject { strategy }
 
-  its(:switchable?) { should be_true }
+  its(:switchable?) { should be true }
   its(:description) { should be_present }
 
   let(:db_result) { [] }

--- a/spec/declaration_strategy_spec.rb
+++ b/spec/declaration_strategy_spec.rb
@@ -8,16 +8,16 @@ describe Flip::DeclarationStrategy do
 
   describe "#knows?" do
     it "does not know definition with no default specified" do
-      subject.knows?(Flip::Definition.new :feature).should be_false
+      subject.knows?(Flip::Definition.new :feature).should be false
     end
     it "does not know definition with default of nil" do
-      subject.knows?(definition(nil)).should be_false
+      subject.knows?(definition(nil)).should be false
     end
     it "knows definition with default set to true" do
-      subject.knows?(definition(true)).should be_true
+      subject.knows?(definition(true)).should be true
     end
     it "knows definition with default set to false" do
-      subject.knows?(definition(false)).should be_true
+      subject.knows?(definition(false)).should be true
     end
   end
 

--- a/spec/feature_set_spec.rb
+++ b/spec/feature_set_spec.rb
@@ -41,26 +41,26 @@ describe Flip::FeatureSet do
   describe "#default= and #on? with null strategy" do
     subject { feature_set_with_null_strategy }
     it "defaults to false" do
-      subject.on?(:feature).should be_false
+      subject.on?(:feature).should be false
     end
     it "can default to true" do
       subject.default = true
-      subject.on?(:feature).should be_true
+      subject.on?(:feature).should be true
     end
     it "accepts a proc returning true" do
       subject.default = proc { true }
-      subject.on?(:feature).should be_true
+      subject.on?(:feature).should be true
     end
     it "accepts a proc returning false" do
       subject.default = proc { false }
-      subject.on?(:feature).should be_false
+      subject.on?(:feature).should be false
     end
   end
 
   describe "feature set with null strategy then always-true strategy" do
     subject { feature_set_with_null_then_true_strategies }
     it "returns true due to second strategy" do
-      subject.on?(:feature).should be_true
+      subject.on?(:feature).should be true
     end
   end
 

--- a/spec/flip_spec.rb
+++ b/spec/flip_spec.rb
@@ -18,16 +18,16 @@ describe Flip do
 
   describe ".on?" do
     it "returns true for enabled features" do
-      Flip.on?(:one).should be_true
+      Flip.on?(:one).should be true
     end
     it "returns false for disabled features" do
-      Flip.on?(:two).should be_false
+      Flip.on?(:two).should be false
     end
   end
 
   describe "dynamic predicate methods" do
-    its(:one?) { should be_true }
-    its(:two?) { should be_false }
+    its(:one?) { should be true }
+    its(:two?) { should be false }
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,2 @@
-require "flip"
+require 'flip'
+require 'rspec/its'


### PR DESCRIPTION
When you run tests you'll receive errors about `be_true` and `be_false` being deprecated. This fixes all of those. In addition, `its` is being removed from rspec core soon and being put into a separate gem and is therefore also deprecated. I added the new rspec-its gem.