### PR TITLE
RSpec deprecation fixed

### DIFF
--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -41,7 +41,7 @@ describe Flip::Cacheable do
 
     context "after a cache clear" do
       before { model_class.start_feature_cache }
-      specify { model_class.use_feature_cache.should be_true }
+      specify { model_class.use_feature_cache.should eq true }
       specify { model_class.feature_cache.size == 3}
     end
   end


### PR DESCRIPTION
(Ruby 1.9.3 Bundler-fails - perhaps we could disable that Travis check.)