### PR TITLE
Bump to support rails 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: ruby
 rvm:
   - 2.3.0
   - 2.2.4
-  - jruby-19mode
+  - jruby-9.0.5.0

--- a/flip.gemspec
+++ b/flip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("activesupport", ">= 3.0", "< 5")
+  s.add_dependency("activesupport", ">= 3.0", "< 5.1")
   s.add_dependency("i18n")
 
   s.add_development_dependency("rspec", "~> 2.5")

--- a/lib/flip/version.rb
+++ b/lib/flip/version.rb
@@ -1,3 +1,3 @@
 module Flip
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
Update to `activesupport` for Rails 5.0.0.