### PR TITLE
Rails 5: Change before_filter to before_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ app/controllers/admin/features_controller.rb:
 
 ```ruby
 class Admin::FeaturesController < Flip::FeaturesController
-  before_filter :assert_authenticated_as_admin
+  before_action :assert_authenticated_as_admin
 end
 ```
 
@@ -142,7 +142,7 @@ app/controllers/admin/strategies_controller.rb:
 
 ```ruby
 class Admin::StrategiesController < Flip::StrategiesController
-  before_filter :assert_authenticated_as_admin
+  before_action :assert_authenticated_as_admin
 end
 ```
 

--- a/lib/flip/controller_filters.rb
+++ b/lib/flip/controller_filters.rb
@@ -1,4 +1,7 @@
 module Flip
+  # ControllerFilters is a name that refers to the fact that Rails
+  # before_action and after_action used to be before_filter and
+  # after_filter.
   module ControllerFilters
 
     extend ActiveSupport::Concern
@@ -6,7 +9,7 @@ module Flip
     module ClassMethods
 
       def require_feature key, options = {}
-        before_filter options do
+        before_action options do
           flip_feature_disabled key unless Flip.on? key
         end
       end

--- a/lib/flip/cookie_strategy.rb
+++ b/lib/flip/cookie_strategy.rb
@@ -47,13 +47,13 @@ module Flip
     end
 
     # Include in ApplicationController to push cookies into CookieStrategy.
-    # Users before_filter and after_filter rather than around_filter to
+    # Uses before_action and after_action rather than around_action to
     # avoid pointlessly adding to stack depth.
     module Loader
       extend ActiveSupport::Concern
       included do
-        before_filter :flip_cookie_strategy_before
-        after_filter :flip_cookie_strategy_after
+        before_action :flip_cookie_strategy_before
+        after_action :flip_cookie_strategy_after
       end
       def flip_cookie_strategy_before
         CookieStrategy.cookies = cookies

--- a/spec/controller_filters_spec.rb
+++ b/spec/controller_filters_spec.rb
@@ -8,16 +8,16 @@ describe ControllerWithFlipFilters do
 
   describe ".require_feature" do
 
-    it "adds before_filter without options" do
+    it "adds before_action without options" do
       ControllerWithFlipFilters.tap do |klass|
-        klass.should_receive(:before_filter).with({})
+        klass.should_receive(:before_action).with({})
         klass.send(:require_feature, :testable)
       end
     end
 
-    it "adds before_filter with options" do
+    it "adds before_action with options" do
       ControllerWithFlipFilters.tap do |klass|
-        klass.should_receive(:before_filter).with({ only: [ :show ] })
+        klass.should_receive(:before_action).with({ only: [ :show ] })
         klass.send(:require_feature, :testable, only: [ :show ])
       end
     end

--- a/spec/cookie_strategy_spec.rb
+++ b/spec/cookie_strategy_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 class ControllerWithoutCookieStrategy; end
 class ControllerWithCookieStrategy
-  def self.before_filter(_); end
-  def self.after_filter(_); end
+  def self.before_action(_); end
+  def self.after_action(_); end
   def cookies; []; end
   include Flip::CookieStrategy::Loader
 end
@@ -76,8 +76,8 @@ describe Flip::CookieStrategy::Loader do
 
   it "adds filters when included in controller" do
     ControllerWithoutCookieStrategy.tap do |klass|
-      klass.should_receive(:before_filter).with(:flip_cookie_strategy_before)
-      klass.should_receive(:after_filter).with(:flip_cookie_strategy_after)
+      klass.should_receive(:before_action).with(:flip_cookie_strategy_before)
+      klass.should_receive(:after_action).with(:flip_cookie_strategy_after)
       klass.send :include, Flip::CookieStrategy::Loader
     end
   end


### PR DESCRIPTION
This PR changes usage of `before_filter` to `before_action`, which avoids deprecation warnings like:

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1.
Use before_action instead. (called from block in <module:Loader> at
 /Users/olle/.../flip-f8dcf8bebed7/lib/flip/cookie_strategy.rb:55)
```

```
DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1.
Use after_action instead. (called from block in <module:Loader> at 
/Users/olle/.../flip-f8dcf8bebed7/lib/flip/cookie_strategy.rb:56)
``` 

Controversy: What's the chosen general solution to this being a multi-version Rails extension? Lots of conditionals in places in the code? If yes, let's put them in!