### PR TITLE
Template for migration: add name and URL to flip project

### DIFF
--- a/lib/generators/flip/migration/templates/create_features.rb
+++ b/lib/generators/flip/migration/templates/create_features.rb
@@ -1,3 +1,4 @@
+# Created by the flip gem, see https://github.com/pda/flip
 class CreateFeatures < ActiveRecord::Migration
   def change
     create_table :features do |t|


### PR DESCRIPTION
This PR adds a single code comment line which explains where this migration came from. 

The name `feature` by itself is quite bare, so this extra hyperlink helps the confounded reader understand what it's about.