### PR TITLE
Allow strategy to be called on arbitrary classes

### DIFF
--- a/lib/flip/abstract_strategy.rb
+++ b/lib/flip/abstract_strategy.rb
@@ -1,6 +1,9 @@
 module Flip
   class AbstractStrategy
 
+    def initialize(_model_class = nil)
+    end
+
     def name
       self.class.name.split("::").last.gsub(/Strategy$/, "").underscore
     end

--- a/lib/flip/declarable.rb
+++ b/lib/flip/declarable.rb
@@ -12,7 +12,7 @@ module Flip
 
     # Adds a strategy for determining feature status.
     def strategy(strategy)
-      FeatureSet.instance.add_strategy strategy
+      FeatureSet.instance.add_strategy strategy, self
     end
 
     # The default response, boolean or a Proc to be called.

--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -32,8 +32,8 @@ module Flip
     end
 
     # Adds a strategy for determing feature status.
-    def add_strategy(strategy)
-      strategy = strategy.new if strategy.is_a? Class
+    def add_strategy(strategy, klass = nil)
+      strategy = strategy.new(klass) if strategy.is_a? Class
       @strategies[strategy.name] = strategy
     end
 

--- a/spec/declarable_spec.rb
+++ b/spec/declarable_spec.rb
@@ -22,6 +22,7 @@ describe Flip::Declarable do
       it { should_not be_on(:one) }
       it { should be_on(:three) }
     end
+
     context "with default set to true" do
       before { model_class.send(:default, true) }
       it { should be_on(:one) }
@@ -29,4 +30,18 @@ describe Flip::Declarable do
     end
   end
 
+  describe "the .strategy class method" do
+    let!(:model_class) do
+      Class.new do
+        extend Flip::Declarable
+      end
+    end
+
+    it "passes the class it's on" do
+      expect(Flip::DeclarationStrategy).to receive(:new)
+        .with(model_class)
+        .and_call_original
+      model_class.strategy Flip::DeclarationStrategy
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, it attempt to use the hardcoded `Feature` class,
whether or not it exists.

So, when I attempted to namespace my Feature class I got the following
error:

```
NameError: uninitialized constant Flip::DatabaseStrategy::Feature
/Users/jcoyne/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/flip-1.1.0/lib/flip/database_strategy.rb:5:in
`initialize'
/Users/jcoyne/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/flip-1.1.0/lib/flip/feature_set.rb:36:in
`new'
/Users/jcoyne/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/flip-1.1.0/lib/flip/feature_set.rb:36:in
`add_strategy'
/Users/jcoyne/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/flip-1.1.0/lib/flip/declarable.rb:15:in
`strategy'
/Users/jcoyne/workspace/curation_concerns/app/models/curation_concerns/feature.rb:6:in
`<class:Feature>'
```