### PR TITLE
Bump to support Rails 5.1

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("activesupport", ">= 3.0", "< 5.1")
+  s.add_dependency("activesupport", ">= 3.0", "< 5.2")
   s.add_dependency("i18n")
 
   s.add_development_dependency("rspec", "~> 2.5")

--- a/lib/flip/version.rb
+++ b/lib/flip/version.rb
@@ -1,3 +1,3 @@
 module Flip
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Why:

* Active Support dependency is currently limited to versions lower than
  5.1.

This change addresses the issue by:

* Bumping the dependency upper limit version, similar to
  8a2e70daa2ed5cea1e31791d5a44edc9ec604471.