### PR TITLE
Consistant trinary strategies

### DIFF
--- a/app/controllers/flip/features_controller.rb
+++ b/app/controllers/flip/features_controller.rb
@@ -30,9 +30,8 @@ module Flip
       end
 
       def strategy_status(strategy, definition)
-        if strategy.knows? definition
-          strategy.on?(definition) ? "on" : "off"
-        end
+        status = strategy.status(definition)
+        { true => 'on', false => 'off', nil => nil }[status]
       end
 
       def switch_url(strategy, definition)

--- a/lib/flip/abstract_strategy.rb
+++ b/lib/flip/abstract_strategy.rb
@@ -8,15 +8,7 @@ module Flip
     def description; ""; end
 
     # Returns true for on, false for off and nil for an unknown state
-    def status definition
-      on?(definition) if knows?(definition)
-    end
-
-    # Whether the strategy knows the on/off state of the switch.
-    def knows? definition; raise; end
-
-    # Given the state is known, whether it is on or off.
-    def on? definition; raise; end
+    def status definition; raise; end
 
     # Whether the feature can be switched on and off at runtime.
     # If true, the strategy must also respond to switch! and delete!

--- a/lib/flip/abstract_strategy.rb
+++ b/lib/flip/abstract_strategy.rb
@@ -7,6 +7,11 @@ module Flip
 
     def description; ""; end
 
+    # Returns true for on, false for off and nil for an unknown state
+    def status definition
+      on?(definition) if knows?(definition)
+    end
+
     # Whether the strategy knows the on/off state of the switch.
     def knows? definition; raise; end
 

--- a/lib/flip/cookie_strategy.rb
+++ b/lib/flip/cookie_strategy.rb
@@ -6,14 +6,12 @@ module Flip
       "Uses cookies to apply only to your session."
     end
 
-    def knows? definition
-      cookies.key? cookie_name(definition)
-    end
-
-    def on? definition
-      cookie = cookies[cookie_name(definition)]
-      cookie_value = cookie.is_a?(Hash) ? cookie['value'] : cookie
-      cookie_value === 'true'
+    def status definition
+      if cookies.key? cookie_name(definition)
+        cookie = cookies[cookie_name(definition)]
+        cookie_value = cookie.is_a?(Hash) ? cookie['value'] : cookie
+        cookie_value === 'true'
+      end
     end
 
     def switchable?

--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -11,9 +11,8 @@ module Flip
     end
 
     def status definition
-      if !!feature(definition)
-        feature(definition).enabled?
-      end
+      feature = feature(definition)
+      feature.enabled? if feature
     end
 
     def switchable?

--- a/lib/flip/database_strategy.rb
+++ b/lib/flip/database_strategy.rb
@@ -10,12 +10,10 @@ module Flip
       "Database backed, applies to all users."
     end
 
-    def knows? definition
-      !!feature(definition)
-    end
-
-    def on? definition
-      feature(definition).enabled?
+    def status definition
+      if !!feature(definition)
+        feature(definition).enabled?
+      end
     end
 
     def switchable?

--- a/lib/flip/declaration_strategy.rb
+++ b/lib/flip/declaration_strategy.rb
@@ -7,13 +7,11 @@ module Flip
       "The default status declared with the feature."
     end
 
-    def knows? definition
-      !definition.options[:default].nil?
-    end
-
-    def on? definition
-      default = definition.options[:default]
-      default.is_a?(Proc) ? default.call(definition) : default
+    def status definition
+      if !definition.options[:default].nil?
+        default = definition.options[:default]
+        default.is_a?(Proc) ? default.call(definition) : default
+      end
     end
 
   end

--- a/lib/flip/feature_set.rb
+++ b/lib/flip/feature_set.rb
@@ -22,8 +22,10 @@ module Flip
     # Whether the given feature is switched on.
     def on? key
       d = @definitions[key]
-      @strategies.each_value { |s| return s.on?(d) if s.knows?(d) }
-      default_for d
+      strategies = @strategies.each_value.lazy
+      status = strategies.map { |s| s.status(d) }.detect { |s| !s.nil? }
+      return default_for d if status.nil? # not known by any strategies
+      status
     end
 
     # Adds a feature definition to the set.

--- a/spec/cookie_strategy_spec.rb
+++ b/spec/cookie_strategy_spec.rb
@@ -23,50 +23,39 @@ describe Flip::CookieStrategy do
   its(:description) { should be_present }
   it { should be_switchable }
 
-  describe "cookie interrogration" do
+  describe "cookie strategy status" do
+    subject { strategy.status(definition) }
+
     context "enabled feature" do
-      specify "#knows? is true" do
-        strategy.knows?(:one).should be true
-      end
-      specify "#on? is true" do
-        strategy.on?(:one).should be true
-      end
+      let(:definition) { :one }
+      it { should be true }
     end
     context "disabled feature" do
-      specify "#knows? is true" do
-        strategy.knows?(:two).should be true
-      end
-      specify "#on? is false" do
-        strategy.on?(:two).should be false
-      end
+      let(:definition) { :two }
+      it { should be false }
     end
     context "feature with no cookie present" do
-      specify "#knows? is false" do
-        strategy.knows?(:three).should be false
-      end
-      specify "#on? is false" do
-        strategy.on?(:three).should be false
-      end
+      let(:definition) { :three }
+      it { should be_nil }
     end
   end
 
   describe "cookie manipulation" do
     it "can switch known features on" do
       strategy.switch! :one, true
-      strategy.on?(:one).should be true
+      strategy.status(:one).should be true
     end
     it "can switch unknown features on" do
       strategy.switch! :three, true
-      strategy.on?(:three).should be true
+      strategy.status(:three).should be true
     end
     it "can switch features off" do
       strategy.switch! :two, false
-      strategy.on?(:two).should be false
+      strategy.status(:two).should be false
     end
     it "can delete knowledge of a feature" do
       strategy.delete! :one
-      strategy.on?(:one).should be false
-      strategy.knows?(:one).should be false
+      strategy.status(:one).should be_nil
     end
   end
 
@@ -91,8 +80,8 @@ describe Flip::CookieStrategy::Loader do
         expect {
           controller.flip_cookie_strategy_before
         }.to change {
-          [ strategy.knows?(:test), strategy.on?(:test) ]
-        }.from([false, false]).to([true, true])
+          strategy.status(:test)
+        }.from(nil).to(true)
       end
     end
     describe "#flip_cookie_strategy_after" do
@@ -103,8 +92,8 @@ describe Flip::CookieStrategy::Loader do
         expect {
           controller.flip_cookie_strategy_after
         }.to change {
-          [ strategy.knows?(:test), strategy.on?(:test) ]
-        }.from([true, true]).to([false, false])
+          strategy.status(:test)
+        }.from(true).to(nil)
       end
     end
   end

--- a/spec/database_strategy_spec.rb
+++ b/spec/database_strategy_spec.rb
@@ -36,7 +36,7 @@ describe Flip::DatabaseStrategy do
 
   context "with a feature definition" do
     before do
-      allow(model_klass).to(receive(:where).with(key: "one").and_return(db_result))
+      allow(model_klass).to(receive(:where).with(key: "one").once.and_return(db_result))
     end
 
     let(:definition) { double("definition", key: "one") }

--- a/spec/declaration_strategy_spec.rb
+++ b/spec/declaration_strategy_spec.rb
@@ -1,39 +1,33 @@
 require "spec_helper"
 
 describe Flip::DeclarationStrategy do
+  describe "#status" do
+    let(:definition) { Flip::Definition.new(:feature, opts) }
+    subject { Flip::DeclarationStrategy.new.status(definition) }
 
-  def definition(default)
-    Flip::Definition.new :feature, default: default
-  end
-
-  describe "#knows?" do
-    it "does not know definition with no default specified" do
-      subject.knows?(Flip::Definition.new :feature).should be false
+    context "no default specified" do
+      let(:opts) { Hash.new }
+      it { should be_nil }
     end
-    it "does not know definition with default of nil" do
-      subject.knows?(definition(nil)).should be false
+    context "default of nil" do
+      let(:opts) { { default: nil } }
+      it { should be_nil }
     end
-    it "knows definition with default set to true" do
-      subject.knows?(definition(true)).should be true
+    context "default set to true" do
+      let(:opts) { { default: true } }
+      it { should be true }
     end
-    it "knows definition with default set to false" do
-      subject.knows?(definition(false)).should be true
+    context "default set to false" do
+      let(:opts) { { default: false } }
+      it { should be false }
     end
-  end
-
-  describe "#on? for Flip::Definition" do
-    subject { Flip::DeclarationStrategy.new.on? definition(default) }
-    [
-      { default: true, result: true },
-      { default: false, result: false },
-      { default: proc { true }, result: true, name: "proc returning true" },
-      { default: proc { false }, result: false, name: "proc returning false" },
-    ].each do |parameters|
-      context "with default of #{parameters[:name] || parameters[:default]}" do
-        let(:default) { parameters[:default] }
-        it { should == parameters[:result] }
-      end
+    context "default proc returning true" do
+      let(:opts) { { default: proc { true } } }
+      it { should be true }
+    end
+    context "default proc returning false" do
+      let(:opts) { { default: proc { false } } }
+      it { should be false }
     end
   end
-
 end


### PR DESCRIPTION
`Flip::DatabaseStrategy` has a consistency/race condition problem -- it double-queries the database to resolve `strategy.on?(feature) if strategy.knows?(feature)`.

This PR fixes the inconsistency by changing the internal API of strategies to be trinary, returning `nil` for "unknown", thereby allowing the strategy to respond in a single consistent db query.

This is also a prerequisite for thread-safety, should that ever be a goal.