### PR TITLE
Fix mismatched cookie domains

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -18,9 +18,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("activesupport", ">= 4.0", "< 5.1")
+  rails_support = [">= 4.0", "<= 5.2"]
+  s.add_dependency("activesupport", *rails_support)
   s.add_dependency("i18n")
 
+  s.add_development_dependency("actionpack", *rails_support)
   s.add_development_dependency("rspec", "~> 3.5")
   s.add_development_dependency("rspec-its")
   s.add_development_dependency("rake")

--- a/lib/flip/cookie_strategy.rb
+++ b/lib/flip/cookie_strategy.rb
@@ -7,11 +7,8 @@ module Flip
     end
 
     def status definition
-      if cookies.key? cookie_name(definition)
-        cookie = cookies[cookie_name(definition)]
-        cookie_value = cookie.is_a?(Hash) ? cookie['value'] : cookie
-        cookie_value === 'true'
-      end
+      cookie = cookies.fetch(cookie_name(definition), nil)
+      cookie == 'true' if cookie
     end
 
     def switchable?
@@ -20,13 +17,13 @@ module Flip
 
     def switch! key, on
       cookies[cookie_name(key)] = {
-        'value' => (on ? "true" : "false"),
-        'domain' => :all
+        value: (on ? "true" : "false"),
+        domain: :all
       }
     end
 
     def delete! key
-      cookies.delete cookie_name(key)
+      cookies.delete(cookie_name(key), domain: :all)
     end
 
     def self.cookies= cookies


### PR DESCRIPTION
CookieStrategy sets cookies for all subdomains from: e9f2dea
and also needs to delete in the same manner

Adds missing tests for setting cookie domains
Use MockRails and ActionDispatch CookieJar objects for accurate testing