### PR TITLE
Relax activesupport version constraint

### DIFF
--- a/flip.gemspec
+++ b/flip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("activesupport", ">= 4.0", "<= 5.2")
+  s.add_dependency("activesupport", ">= 4.0", "< 6")
   s.add_dependency("i18n")
 
   s.add_development_dependency("actionpack")


### PR DESCRIPTION
Right now this prevents installing any patch releases of Rails 5.2.

Given the Gemfile:
```
source 'https://rubygems.org'

gem 'flip', github: 'pda/flip'
gem 'activesupport', '~> 5.2.3'
```

Running `bundle install` gives:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    activesupport (~> 5.2.3)

    flip was resolved to 1.1.1, which depends on
      activesupport (>= 4.0, <= 5.2)
```
